### PR TITLE
Chore: switch status to CG-DRAFT

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,6 +1,6 @@
 <h1>Crash Reporting</h1>
 <pre class="metadata">
-Status: ED
+Status: CG-DRAFT
 ED: https://wicg.github.io/crash-reporting/
 Shortname: crash-reporting
 Group: WICG


### PR DESCRIPTION
We reserve ED for W3C Working Group working drafts.