### PR TITLE
Introduce the `CrashReportContext` interface

### DIFF
--- a/crashReport-explainer.md
+++ b/crashReport-explainer.md
@@ -51,18 +51,23 @@ encounter with more precision.
 
 ### Detailed design
 
-We propose a straightforward `CrashReportStorage` Web IDL interface, with a key/value setter, and
+We propose a straightforward `CrashReportContext` Web IDL interface, with a key/value setter, and
 removal method:
 
 ```js
 [Exposed=Window]
-interface CrashReportStorage {
+interface CrashReportContext {
+  Promise<undefined> initialize(unsigned long long length);
   void set(DOMString key, DOMString value);
-  void remove(DOMString key);
+  void delete(DOMString key);
 };
 ```
 
-Both `set()` and `remove()` are synchronous, and expected to be implemented either by a backing blob
+The `initialize()` method must be called before either `set()` or `delete()`, and provides the
+implementation with the ability to asynchronously initialize any backing memory that is used for the
+crash report data supplied via `set()`.
+
+Both `set()` and `delete()` are synchronous, and expected to be implemented either by a backing blob
 of shared memory that spans between the crashing process and the process that reports on its crash,
 a synchronous IPC call, or some other equivalently reliable mechanism.
 
@@ -77,7 +82,7 @@ a synchronous IPC call, or some other equivalently reliable mechanism.
 
 **Scoping**
 
-The scope of key-value map backing the `CrashReportStorage` interface is Document-bound. Because it
+The scope of key-value map backing the `CrashReportContext` interface is Document-bound. Because it
 is 1:1 with a Document, storage partitioning considerations that are relevant for other traditional
 "storage" APIs are not necessary—this API is just additional Document state.
 
@@ -117,7 +122,7 @@ window.crashReport.set('complex-operation-input', String(arg1 + arg2));
 // If the following operation crashes, then its inputs will be sent in a `CrashReportBody` to the
 default endpoint.
 complexOperationThatMightCrash(arg1, arg2);
-window.crashReport.remove('complex-operation-input');
+window.crashReport.delete('complex-operation-input');
 ```
 
 Note that because crash storage data is accessible among all same-origin Documents under a

--- a/index.bs
+++ b/index.bs
@@ -19,9 +19,15 @@ Include MDN Panels: no
 <pre class="anchors">
 url: https://tc39.es/proposal-error-stacks/#sec-get-error.prototype-stack; type: dfn; spec: ERROR STACKS
   text: Error.prototype.stack
+url: https://html.spec.whatwg.org/C#unique-internal-value; type: dfn;
+  text: unique internal value
+url: https://html.spec.whatwg.org/C#new-unique-internal-value; type: dfn
+  text: new unique internal value
 </pre>
 <pre class="link-defaults">
   spec:dom; type:dfn; for:/; text:document
+  spec:infra; type:dfn; text:user agent
+  spec:webidl; type:interface; text:any
 </pre>
 
 Introduction {#intro}
@@ -76,6 +82,7 @@ dictionary CrashReportBody : ReportBody {
   DOMString stack;
   boolean is_top_level;
   DocumentVisibilityState visibility_state;
+  object crash_report_api;
 };
 </xmp>
 
@@ -124,6 +131,13 @@ A [=crash report=]'s [=report/body=], represented in JavaScript by
   It represents whether the visual viewport that the crashed {{Document}} was hosted in was
   visible at all, or fully occluded.
 
+* <dfn for="CrashReportBody" noexport>crash_report_api</dfn>: A JSON dictionary of arbitrary
+  key/value data obtained by deserializing the memory buffer in [=user agent=]'s [=user
+  agent/crash report buffers=] map, identified by a crashing {{Document}}'s
+  {{CrashReportContext}}'s [=CrashReportContext/backing buffer ID=] member. This buffer is
+  deserialized as a JSON-formatted string, and its keys and values are appended to this {{any}}
+  object member of the {{CrashReportBody}}.
+
 Note: Crash reports are not observable to JavaScript, as the page which would
 receive them is, by definition, not able to. The IDL description of
 CrashReportBody exists in this spec to provide a JSON-seriaizable interface
@@ -142,6 +156,183 @@ If neither [=endpoint=] is specified, [=crash reports=] are not delivered.
     Reporting-Endpoints: crash-reporting="https://example.com/reports"
   </pre>
 </div>
+
+The {{CrashReportContext}} interface {#crash-report-storage}
+===========================
+
+<pre class="idl">
+  partial interface Window {
+    readonly attribute CrashReportContext crashReport;
+  };
+</pre>
+
+Each {{Window}} object has an associated <dfn for=Window>crashReport</dfn>, which is a
+{{CrashReportContext}} instance created alongside the {{Window}}.
+
+<div algorithm>
+  The <dfn attribute for=Window>crashReport</dfn> getter steps are:
+    1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully
+       active=], then return null.
+
+    1. Return [=this=]'s [=relevant global object=]'s [=Window/crashReport=] object.
+
+  <wpt>
+    /reporting/crashReport-test.html
+  </wpt>
+</div>
+
+<pre class="idl">
+  [Exposed=Window]
+  interface CrashReportContext {
+      Promise&lt;undefined&gt; initialize(unsigned long long length);
+      undefined set(DOMString key, DOMString value);
+      undefined delete(DOMString key);
+  };
+</pre>
+
+Each {{CrashReportContext}} object has an associated <dfn for=CrashReportContext>internal map</dfn>,
+which is a [=map=] whose [=map/keys=] and [=map/values=] are both {{DOMString}}s.
+
+The [=user agent=] has an associated <dfn for="user agent">crash report buffers</dfn>, which is a
+[=map=] whose [=map/keys=] are [=unique internal values=] and whose [=map/values=] are [=implementation-defined=] values.
+
+Note: The [=CrashReportContext/internal map=] is a map-representation of the data that will
+eventually appear in a crash report, and it exists to ergonomically interact with this data via
+[=map=] semantics. But implementations of this specification, especially those supporting site
+isolation, will likely ultimately serialize its entire contents to a backing shared memory buffer
+tracked by the [=user agent=]'s [=user agent/crash report buffers=] map. The [=map/values=] of that
+map are expected to be those memory buffers that span the web process and whatever OS process is
+responsible for sending crash reports when a web process crashes, and its
+[=CrashReportContext/internal map=] is no longer available to read from.
+
+Each {{CrashReportContext}} object has an associated <dfn for=CrashReportContext>backing buffer
+ID</dfn>, which is a null-or-[=unique internal value=]; it is initially null.
+
+Each {{CrashReportContext}} object has an associated <dfn for=CrashReportContext>is buffer
+initialized</dfn> [=boolean=], which is initially false.
+
+Note: This member is asynchronously set to true when the backing memory buffer associated with
+[=this=]'s [=CrashReportContext/backing buffer ID=] is initialized.
+
+Each {{CrashReportContext}} object has an associated {{unsigned long long}} <dfn
+for=CrashReportContext>buffer length</dfn>, which is initially 0.
+
+Note: This gets assigned once in {{CrashReportContext/initialize()}}, and tracks the maximum number
+of bytes that any call to {{CrashReportContext/set()}} can write to the memory backing
+[=CrashReportContext/internal map=].
+
+<p class=note>The [=CrashReportContext/internal map=] is used to hold all keys/values that will be
+supplied to the developer via {{CrashReportBody}}s. In browsers with site isolation, the physical
+process that writes to this data is different from the one that reads from it and sends the [=crash
+reports=]. Therefore, it is expected that implementations maintain this map as a shared memory
+buffer spanning the two processes. This is what the Chromium implementation of this API does.</p>
+
+<div algorithm>
+  The <dfn method for=CrashReportContext>initialize(|length|)</dfn> method steps are:
+
+    1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully
+       active=], then [=throw=] a [=new=] "{{InvalidStateError}}" {{DOMException}}.
+
+       Note: This will be surfaced to the user via a rejected {{Promise}}.
+
+    1. If [=this=]'s [=CrashReportContext/backing buffer ID=] is non-null, then [=throw=] a [=new=]
+       "{{InvalidStateError}}" {{DOMException}}.
+
+    1. If |length| is &gt; than 5 \* 1024 \* 1024, then [=throw=] a [=new=] "{{NotAllowedError}}"
+       {{DOMException}}.
+
+       Note: The limit for the crash report memory buffer is 5 megabytes.
+
+    1. Set [=this=]'s [=CrashReportContext/buffer length=] to |length|.
+
+    1. Set [=this=]'s [=CrashReportContext/backing buffer ID=] to the result of [=new unique
+       internal value|creating a new unique internal value=].
+
+    1. Let |cachedThis| be [=this=].
+
+    1. Let |promise| be a [=a new promise=].
+
+    1. Run these steps [=in parallel=]:
+
+       1. Let |backing buffer ID| be |cachedThis|'s [=CrashReportContext/backing buffer ID=].
+
+       1. Run [=implementation-defined=] steps to create and initialize a backing memory store of
+          |length| bytes.
+
+       1. If such a buffer was created, then:
+
+          1. Set the [=user agent=]'s [=user agent/crash report buffers=][|backing buffer ID|] to the
+             buffer.
+
+          1. Set |cachedThis|'s [=CrashReportContext/is buffer initialized=] to true.
+
+       1. [=Queue a global task=] on the [=DOM manipulation task source=] given |cachedThis|'s
+          [=relevant global object=], to [=resolve=] |promise| with {{undefined}}.
+
+    1. Return |promise|.
+
+  <wpt>
+    /reporting/crashReport-test.html
+  </wpt>
+</div>
+
+<div algorithm>
+  The <dfn method for=CrashReportContext>set(|key|, |value|)</dfn> method steps are:
+
+    1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully
+       active=], then [=throw=] a [=new=] "{{InvalidStateError}}" {{DOMException}}.
+
+    1. If [=this=]'s [=CrashReportContext/is buffer initialized=] is false, then [=throw=] a [=new=]
+       "{{InvalidStateError}}" {{DOMException}}.
+
+       Note: This will be false both before {{CrashReportContext/initialize()}} is called, and
+       *after* it is called but before its returned {{Promise}} resolves. It ensures that
+       {{CrashReportContext/set()}} only works when the backing buffer identified by the
+       [=CrashReportContext/backing buffer ID=] is fully initialized.
+
+    1. [=map/Set=] [=this=]'s [=CrashReportContext/internal map=][|key|] to |value|.
+
+    1. Let |serialization| be the result of [=serializing a JavaScript value to JSON bytes=], given
+       [=this=]'s [=CrashReportContext/internal map=].
+
+    1. If |serialization|'s [=list/size=] is &gt; [=this=]'s [=CrashReportContext/buffer length=], then:
+
+       1. [=map/Remove=] [=this=]'s [=CrashReportContext/internal map=][|key|].
+
+       1. [=Throw=] a [=new=] "{{NotAllowedError}}" {{DOMException}}.
+
+    1. Let |backing buffer ID| be [=this=]'s [=CrashReportContext/backing buffer ID=].
+
+    1. Write |serialization| to the [=user agent=]'s [=crash report buffers=][|backing buffer ID|].
+
+  <wpt>
+    /reporting/crashReport-test.html
+  </wpt>
+</div>
+
+<div algorithm>
+  The <dfn method for=CrashReportContext>delete(|key|)</dfn> method steps are:
+
+    1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully
+       active=], then [=throw=] a [=new=] "{{InvalidStateError}}" {{DOMException}}.
+
+    1. If [=this=]'s [=CrashReportContext/is buffer initialized=] is false, then [=throw=] a [=new=]
+       "{{InvalidStateError}}" {{DOMException}}.
+
+    1. [=map/Remove=] [=this=]'s [=CrashReportContext/internal map=][|key|].
+
+    1. Let |serialization| be the result of [=serializing a JavaScript value to JSON bytes=], given
+       [=this=]'s [=CrashReportContext/internal map=].
+
+    1. Let |backing buffer ID| be [=this=]'s [=CrashReportContext/backing buffer ID=].
+
+    1. Write |serialization| to the [=user agent=]'s [=crash report buffers=][|backing buffer ID|].
+
+  <wpt>
+    /reporting/crashReport-test.html
+  </wpt>
+</div>
+
 
 Document Policy Integration {#document-policy}
 ===========================

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 3f621ba99, updated Mon Jul 28 15:38:36 2025 -0700" name="generator">
   <link href="https://wicg.github.io/crash-reporting/" rel="canonical">
-  <meta content="cfb110b9a8add20ebeae92fcf97cff14bb8b78b2" name="revision">
+  <meta content="f6dbeb57c3e78b7d03a70e64534d285e0f4133bf" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>/* Boilerplate: style-autolinks */

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 3f621ba99, updated Mon Jul 28 15:38:36 2025 -0700" name="generator">
   <link href="https://wicg.github.io/crash-reporting/" rel="canonical">
-  <meta content="e2da536714581ff768a9e6327aed62e2424056a7" name="revision">
+  <meta content="cfb110b9a8add20ebeae92fcf97cff14bb8b78b2" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>/* Boilerplate: style-autolinks */
@@ -690,11 +690,54 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     c-[il] { color: #657b83 } /* Literal.Number.Integer.Long */
 }
 </style>
+<style>/* Boilerplate: style-var-click-highlighting */
+/*
+Colors were chosen in Lab using https://nixsensor.com/free-color-converter/
+D50 2deg illuminant, L in [0,100], a and b in [-128, 128]
+0 = lab(85,0,85)
+1 = lab(85,80,30)
+2 = lab(85,-40,40)
+3 = lab(85,-50,0)
+4 = lab(85,5,15)
+5 = lab(85,-10,-50)
+6 = lab(85,35,-15)
+
+For darkmode:
+0 = oklab(50%   0%  108%)
+1 = oklab(50% -51%   51%)
+2 = oklab(50% -64%  -20%)
+3 = oklab(50%   6%   19%)
+4 = oklab(50% -12%  -64%)
+5 = oklab(50%  44%  -19%)  
+6 = oklab(50% 102%   38%)
+*/
+
+[data-algorithm] var { cursor: pointer; }
+var[data-var-color] { background-color: var(--var-bg); box-shadow: 0 0 0 2px var(--var-bg); }
+
+var[data-var-color] { --var-bg: #F4D200; }
+var[data-var-color="1"] { --var-bg: #FF87A2; }
+var[data-var-color="2"] { --var-bg: #96E885; }
+var[data-var-color="3"] { --var-bg: #3EEED2; }
+var[data-var-color="4"] { --var-bg: #EACFB6; }
+var[data-var-color="5"] { --var-bg: #82DDFF; }
+var[data-var-color="6"] { --var-vg: #FFBCF2; }
+
+@media (prefers-color-scheme: dark) {
+	var[data-var-color] { --var-bg: #bc1a00; }
+	var[data-var-color="1"] { --var-bg: #007f00; }
+	var[data-var-color="2"] { --var-bg: #008698; }
+	var[data-var-color="3"] { --var-bg: #7f5b2b; }
+	var[data-var-color="4"] { --var-bg: #004df3; }
+	var[data-var-color="5"] { --var-bg: #a1248a; }
+	var[data-var-color="6"] { --var-vg: #ff0000; }
+}
+</style>
  <body class="h-entry">
   <div class="head">
    <h1 class="p-name no-ref" id="title">Crash Reporting</h1>
    <p id="w3c-state"><a href="https://www.w3.org/standards/types/#CG-DRAFT">Draft Community Group Report</a>,
-    <time class="dt-updated" datetime="2025-11-20">20 November 2025</time></p>
+    <time class="dt-updated" datetime="2026-02-02">2 February 2026</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -705,10 +748,12 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd class="editor p-author h-card vcard" data-editor-id="76841"><a class="p-name fn u-email email" href="mailto:iclelland@google.com">Ian Clelland</a> (<span class="p-org org">Google Inc.</span>)
      <dt>Participate:
      <dd><a href="https://github.com/WICG/crash-reporting/issues/new">File an issue</a> (<a href="https://github.com/WICG/crash-reporting/issues">open issues</a>)
+     <dt>Test Suite:
+     <dd class="wpt-overview"><a href="https://wpt.fyi/results/reporting/">https://wpt.fyi/results/reporting/</a>
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2025 the Contributors to the Crash Reporting Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2026 the Contributors to the Crash Reporting Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
 A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.
 </p>
    <hr title="Separator for header">
@@ -755,18 +800,19 @@ through the use of the Reporting API.</p>
      <ol class="toc">
       <li><a href="#delivery-priority"><span class="secno">3.1</span> <span class="content"><span>Crash Reports</span> Delivery Priority</span></a>
      </ol>
-    <li><a href="#document-policy"><span class="secno">4</span> <span class="content">Document Policy Integration</span></a>
+    <li><a href="#crash-report-storage"><span class="secno">4</span> <span class="content">The <code class="idl"><span>CrashReportContext</span></code> interface</span></a>
+    <li><a href="#document-policy"><span class="secno">5</span> <span class="content">Document Policy Integration</span></a>
     <li>
-     <a href="#implementation"><span class="secno">5</span> <span class="content">Implementation Considerations</span></a>
+     <a href="#implementation"><span class="secno">6</span> <span class="content">Implementation Considerations</span></a>
      <ol class="toc">
-      <li><a href="#delivery"><span class="secno">5.1</span> <span class="content">Delivery</span></a>
+      <li><a href="#delivery"><span class="secno">6.1</span> <span class="content">Delivery</span></a>
      </ol>
-    <li><a href="#sample-reports"><span class="secno">6</span> <span class="content">Sample Reports</span></a>
-    <li><a href="#security"><span class="secno">7</span> <span class="content">Security Considerations</span></a>
+    <li><a href="#sample-reports"><span class="secno">7</span> <span class="content">Sample Reports</span></a>
+    <li><a href="#security"><span class="secno">8</span> <span class="content">Security Considerations</span></a>
     <li>
-     <a href="#privacy"><span class="secno">8</span> <span class="content">Privacy Considerations</span></a>
+     <a href="#privacy"><span class="secno">9</span> <span class="content">Privacy Considerations</span></a>
      <ol class="toc">
-      <li><a href="#cross-process-contamination"><span class="secno">8.1</span> <span class="content">Cross-Process Contamination</span></a>
+      <li><a href="#cross-process-contamination"><span class="secno">9.1</span> <span class="content">Cross-Process Contamination</span></a>
      </ol>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
@@ -813,6 +859,7 @@ optionally the reason for the crash (such as "oom").</p>
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="CrashReportBody" data-dfn-type="dict-member" data-export data-type="DOMString" id="dom-crashreportbody-stack"><code><c- g>stack</c-></code></dfn>;
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="CrashReportBody" data-dfn-type="dict-member" data-export data-type="boolean" id="dom-crashreportbody-is_top_level"><code><c- g>is_top_level</c-></code></dfn>;
   <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#documentvisibilitystate" id="ref-for-documentvisibilitystate"><c- n>DocumentVisibilityState</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="CrashReportBody" data-dfn-type="dict-member" data-export data-type="DocumentVisibilityState" id="dom-crashreportbody-visibility_state"><code><c- g>visibility_state</c-></code></dfn>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-object" id="ref-for-idl-object"><c- b>object</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="CrashReportBody" data-dfn-type="dict-member" data-export data-type="object" id="dom-crashreportbody-crash_report_api"><code><c- g>crash_report_api</c-></code></dfn>;
 };
 </pre>
    <p>A <a data-link-type="dfn" href="#crash-reports" id="ref-for-crash-reports②">crash report</a>’s <a data-link-type="dfn" href="https://w3c.github.io/reporting/#report-body" id="ref-for-report-body">body</a>, represented in JavaScript by
@@ -860,6 +907,12 @@ whether the <code class="idl"><a data-link-type="idl" href="https://dom.spec.wha
 enum that is exposed to the web platform, via <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code>.<code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/interaction.html#dom-document-visibilitystate" id="ref-for-dom-document-visibilitystate">visibilityState</a></code>.
 It represents whether the visual viewport that the crashed <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> was hosted in was
 visible at all, or fully occluded.</p>
+    <li data-md>
+     <p><dfn class="dfn-paneled" data-dfn-for="CrashReportBody" data-dfn-type="dfn" data-noexport id="crashreportbody-crash_report_api">crash_report_api</dfn>: A JSON dictionary of arbitrary
+key/value data obtained by deserializing the memory buffer in <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#user-agent" id="ref-for-user-agent">user agent</a>’s <a data-link-type="dfn" href="#user-agent-crash-report-buffers" id="ref-for-user-agent-crash-report-buffers">crash report buffers</a> map, identified by a crashing <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code>’s
+<code class="idl"><a data-link-type="idl" href="#crashreportcontext" id="ref-for-crashreportcontext">CrashReportContext</a></code>’s <a data-link-type="dfn" href="#crashreportcontext-backing-buffer-id" id="ref-for-crashreportcontext-backing-buffer-id">backing buffer ID</a> member. This buffer is
+deserialized as a JSON-formatted string, and its keys and values are appended to this <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-any" id="ref-for-idl-any">any</a></code>
+object member of the <code class="idl"><a data-link-type="idl" href="#dictdef-crashreportbody" id="ref-for-dictdef-crashreportbody①">CrashReportBody</a></code>.</p>
    </ul>
    <p class="note" role="note"><span class="marker">Note:</span> Crash reports are not observable to JavaScript, as the page which would
 receive them is, by definition, not able to. The IDL description of
@@ -878,7 +931,163 @@ If a <code>crash-reporting</code> <a data-link-type="dfn" href="https://w3c.gith
 <pre>Reporting-Endpoints: crash-reporting="https://example.com/reports"
 </pre>
    </div>
-   <h2 class="heading settled" data-level="4" id="document-policy"><span class="secno">4. </span><span class="content">Document Policy Integration</span><a class="self-link" href="#document-policy"></a></h2>
+   <h2 class="heading settled" data-level="4" id="crash-report-storage"><span class="secno">4. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#crashreportcontext" id="ref-for-crashreportcontext①">CrashReportContext</a></code> interface</span><a class="self-link" href="#crash-report-storage"></a></h2>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window" id="ref-for-window"><c- g>Window</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#crashreportcontext" id="ref-for-crashreportcontext②"><c- n>CrashReportContext</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="CrashReportContext" href="#dom-window-crashreport" id="ref-for-dom-window-crashreport"><c- g>crashReport</c-></a>;
+};
+</pre>
+   <p>Each <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window" id="ref-for-window①">Window</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="Window" data-dfn-type="dfn" data-noexport id="window-crashreport">crashReport</dfn>, which is a
+<code class="idl"><a data-link-type="idl" href="#crashreportcontext" id="ref-for-crashreportcontext③">CrashReportContext</a></code> instance created alongside the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window" id="ref-for-window②">Window</a></code>.</p>
+   <div class="algorithm" data-algorithm="crashReport" data-algorithm-for="Window">
+    
+  The <dfn class="dfn-paneled idl-code" data-dfn-for="Window" data-dfn-type="attribute" data-export id="dom-window-crashreport"><code>crashReport</code></dfn> getter steps are:
+
+    <ol>
+     <li data-md>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this">this</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global">relevant global object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window" id="ref-for-concept-document-window">associated Document</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active" id="ref-for-fully-active">fully active</a>, then return null.</p>
+     <li data-md>
+      <p>Return <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①">this</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global①">relevant global object</a>’s <a data-link-type="dfn" href="#window-crashreport" id="ref-for-window-crashreport">crashReport</a> object.</p>
+    </ol>
+   </div>
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="crashreportcontext"><code><c- g>CrashReportContext</c-></code></dfn> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-crashreportcontext-initialize" id="ref-for-dom-crashreportcontext-initialize"><c- g>initialize</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="CrashReportContext/initialize(length)" data-dfn-type="argument" data-export id="dom-crashreportcontext-initialize-length-length"><code><c- g>length</c-></code></dfn>);
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined①"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-crashreportcontext-set" id="ref-for-dom-crashreportcontext-set"><c- g>set</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="CrashReportContext/set(key, value)" data-dfn-type="argument" data-export id="dom-crashreportcontext-set-key-value-key"><code><c- g>key</c-></code></dfn>, <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="CrashReportContext/set(key, value)" data-dfn-type="argument" data-export id="dom-crashreportcontext-set-key-value-value"><code><c- g>value</c-></code></dfn>);
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined②"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-crashreportcontext-delete" id="ref-for-dom-crashreportcontext-delete"><c- g>delete</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString④"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="CrashReportContext/delete(key)" data-dfn-type="argument" data-export id="dom-crashreportcontext-delete-key-key"><code><c- g>key</c-></code></dfn>);
+};
+</pre>
+   <p>Each <code class="idl"><a data-link-type="idl" href="#crashreportcontext" id="ref-for-crashreportcontext④">CrashReportContext</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="CrashReportContext" data-dfn-type="dfn" data-noexport id="crashreportcontext-internal-map">internal map</dfn>,
+which is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-getting-the-keys" id="ref-for-map-getting-the-keys">keys</a> and <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-getting-the-values" id="ref-for-map-getting-the-values">values</a> are both <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString⑤">DOMString</a></code>s.</p>
+   <p>The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#user-agent" id="ref-for-user-agent①">user agent</a> has an associated <dfn class="dfn-paneled" data-dfn-for="user agent" data-dfn-type="dfn" data-noexport id="user-agent-crash-report-buffers">crash report buffers</dfn>, which is a
+<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map①">map</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-getting-the-keys" id="ref-for-map-getting-the-keys①">keys</a> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/C#unique-internal-value" id="ref-for-unique-internal-value">unique internal values</a> and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-getting-the-values" id="ref-for-map-getting-the-values①">values</a> are <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#implementation-defined" id="ref-for-implementation-defined">implementation-defined</a> values.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> The <a data-link-type="dfn" href="#crashreportcontext-internal-map" id="ref-for-crashreportcontext-internal-map">internal map</a> is a map-representation of the data that will
+eventually appear in a crash report, and it exists to ergonomically interact with this data via
+<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map②">map</a> semantics. But implementations of this specification, especially those supporting site
+isolation, will likely ultimately serialize its entire contents to a backing shared memory buffer
+tracked by the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#user-agent" id="ref-for-user-agent②">user agent</a>’s <a data-link-type="dfn" href="#user-agent-crash-report-buffers" id="ref-for-user-agent-crash-report-buffers①">crash report buffers</a> map. The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-getting-the-values" id="ref-for-map-getting-the-values②">values</a> of that
+map are expected to be those memory buffers that span the web process and whatever OS process is
+responsible for sending crash reports when a web process crashes, and its
+<a data-link-type="dfn" href="#crashreportcontext-internal-map" id="ref-for-crashreportcontext-internal-map①">internal map</a> is no longer available to read from.</p>
+   <p>Each <code class="idl"><a data-link-type="idl" href="#crashreportcontext" id="ref-for-crashreportcontext⑤">CrashReportContext</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="CrashReportContext" data-dfn-type="dfn" data-lt="backing buffer ID" data-noexport id="crashreportcontext-backing-buffer-id">backing buffer
+ID</dfn>, which is a null-or-<a data-link-type="dfn" href="https://html.spec.whatwg.org/C#unique-internal-value" id="ref-for-unique-internal-value①">unique internal value</a>; it is initially null.</p>
+   <p>Each <code class="idl"><a data-link-type="idl" href="#crashreportcontext" id="ref-for-crashreportcontext⑥">CrashReportContext</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="CrashReportContext" data-dfn-type="dfn" data-lt="is buffer initialized" data-noexport id="crashreportcontext-is-buffer-initialized">is buffer
+initialized</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean" id="ref-for-boolean">boolean</a>, which is initially false.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> This member is asynchronously set to true when the backing memory buffer associated with
+<a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-backing-buffer-id" id="ref-for-crashreportcontext-backing-buffer-id①">backing buffer ID</a> is initialized.</p>
+   <p>Each <code class="idl"><a data-link-type="idl" href="#crashreportcontext" id="ref-for-crashreportcontext⑦">CrashReportContext</a></code> object has an associated <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long①">unsigned long long</a></code> <dfn class="dfn-paneled" data-dfn-for="CrashReportContext" data-dfn-type="dfn" data-noexport id="crashreportcontext-buffer-length">buffer length</dfn>, which is initially 0.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> This gets assigned once in <code class="idl"><a data-link-type="idl" href="#dom-crashreportcontext-initialize" id="ref-for-dom-crashreportcontext-initialize①">initialize()</a></code>, and tracks the maximum number
+of bytes that any call to <code class="idl"><a data-link-type="idl" href="#dom-crashreportcontext-set" id="ref-for-dom-crashreportcontext-set①">set()</a></code> can write to the memory backing
+<a data-link-type="dfn" href="#crashreportcontext-internal-map" id="ref-for-crashreportcontext-internal-map②">internal map</a>.</p>
+   <p class="note" role="note">The <a data-link-type="dfn" href="#crashreportcontext-internal-map" id="ref-for-crashreportcontext-internal-map③">internal map</a> is used to hold all keys/values that will be
+supplied to the developer via <code class="idl"><a data-link-type="idl" href="#dictdef-crashreportbody" id="ref-for-dictdef-crashreportbody②">CrashReportBody</a></code>s. In browsers with site isolation, the physical
+process that writes to this data is different from the one that reads from it and sends the <a data-link-type="dfn" href="#crash-reports" id="ref-for-crash-reports⑦">crash reports</a>. Therefore, it is expected that implementations maintain this map as a shared memory
+buffer spanning the two processes. This is what the Chromium implementation of this API does.</p>
+   <div class="algorithm" data-algorithm="initialize(length)" data-algorithm-for="CrashReportContext">
+    
+  The <dfn class="dfn-paneled idl-code" data-dfn-for="CrashReportContext" data-dfn-type="method" data-export id="dom-crashreportcontext-initialize"><code>initialize(<var>length</var>)</code></dfn> method steps are:
+
+
+    <ol>
+     <li data-md>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③">this</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global②">relevant global object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window" id="ref-for-concept-document-window①">associated Document</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active" id="ref-for-fully-active①">fully active</a>, then <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-throw" id="ref-for-dfn-throw">throw</a> a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new">new</a> "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code>.</p>
+      <p class="note" role="note"><span class="marker">Note:</span> This will be surfaced to the user via a rejected <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①">Promise</a></code>.</p>
+     <li data-md>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-backing-buffer-id" id="ref-for-crashreportcontext-backing-buffer-id②">backing buffer ID</a> is non-null, then <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-throw" id="ref-for-dfn-throw①">throw</a> a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new①">new</a>
+ "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException①">DOMException</a></code>.</p>
+     <li data-md>
+      <p>If <var>length</var> is > than 5 * 1024 * 1024, then <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-throw" id="ref-for-dfn-throw②">throw</a> a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new②">new</a> "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror">NotAllowedError</a></code>"
+ <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException②">DOMException</a></code>.</p>
+      <p class="note" role="note"><span class="marker">Note:</span> The limit for the crash report memory buffer is 5 megabytes.</p>
+     <li data-md>
+      <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑤">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-buffer-length" id="ref-for-crashreportcontext-buffer-length">buffer length</a> to <var>length</var>.</p>
+     <li data-md>
+      <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑥">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-backing-buffer-id" id="ref-for-crashreportcontext-backing-buffer-id③">backing buffer ID</a> to the result of <a data-link-type="dfn" href="https://html.spec.whatwg.org/C#new-unique-internal-value" id="ref-for-new-unique-internal-value">creating a new unique internal value</a>.</p>
+     <li data-md>
+      <p>Let <var>cachedThis</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑦">this</a>.</p>
+     <li data-md>
+      <p>Let <var>promise</var> be a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#a-new-promise" id="ref-for-a-new-promise">a new promise</a>.</p>
+     <li data-md>
+      <p>Run these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>backing buffer ID</var> be <var>cachedThis</var>’s <a data-link-type="dfn" href="#crashreportcontext-backing-buffer-id" id="ref-for-crashreportcontext-backing-buffer-id④">backing buffer ID</a>.</p>
+       <li data-md>
+        <p>Run <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#implementation-defined" id="ref-for-implementation-defined①">implementation-defined</a> steps to create and initialize a backing memory store of
+  <var>length</var> bytes.</p>
+       <li data-md>
+        <p>If such a buffer was created, then:</p>
+        <ol>
+         <li data-md>
+          <p>Set the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#user-agent" id="ref-for-user-agent③">user agent</a>’s <a data-link-type="dfn" href="#user-agent-crash-report-buffers" id="ref-for-user-agent-crash-report-buffers②">crash report buffers</a>[<var>backing buffer ID</var>] to the
+ buffer.</p>
+         <li data-md>
+          <p>Set <var>cachedThis</var>’s <a data-link-type="dfn" href="#crashreportcontext-is-buffer-initialized" id="ref-for-crashreportcontext-is-buffer-initialized">is buffer initialized</a> to true.</p>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task" id="ref-for-queue-a-global-task">Queue a global task</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source" id="ref-for-dom-manipulation-task-source">DOM manipulation task source</a> given <var>cachedThis</var>’s
+  <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global③">relevant global object</a>, to <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#resolve" id="ref-for-resolve">resolve</a> <var>promise</var> with <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined③">undefined</a></code>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>promise</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="set(key, value)" data-algorithm-for="CrashReportContext">
+    
+  The <dfn class="dfn-paneled idl-code" data-dfn-for="CrashReportContext" data-dfn-type="method" data-export id="dom-crashreportcontext-set"><code>set(<var>key</var>, <var>value</var>)</code></dfn> method steps are:
+
+
+    <ol>
+     <li data-md>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑧">this</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global④">relevant global object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window" id="ref-for-concept-document-window②">associated Document</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active" id="ref-for-fully-active②">fully active</a>, then <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-throw" id="ref-for-dfn-throw③">throw</a> a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new③">new</a> "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror②">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException③">DOMException</a></code>.</p>
+     <li data-md>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑨">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-is-buffer-initialized" id="ref-for-crashreportcontext-is-buffer-initialized①">is buffer initialized</a> is false, then <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-throw" id="ref-for-dfn-throw④">throw</a> a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new④">new</a>
+ "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror③">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException④">DOMException</a></code>.</p>
+      <p class="note" role="note"><span class="marker">Note:</span> This will be false both before <code class="idl"><a data-link-type="idl" href="#dom-crashreportcontext-initialize" id="ref-for-dom-crashreportcontext-initialize②">initialize()</a></code> is called, and
+ <em>after</em> it is called but before its returned <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise②">Promise</a></code> resolves. It ensures that
+ <code class="idl"><a data-link-type="idl" href="#dom-crashreportcontext-set" id="ref-for-dom-crashreportcontext-set②">set()</a></code> only works when the backing buffer identified by the
+ <a data-link-type="dfn" href="#crashreportcontext-backing-buffer-id" id="ref-for-crashreportcontext-backing-buffer-id⑤">backing buffer ID</a> is fully initialized.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set">Set</a> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⓪">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-internal-map" id="ref-for-crashreportcontext-internal-map④">internal map</a>[<var>key</var>] to <var>value</var>.</p>
+     <li data-md>
+      <p>Let <var>serialization</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-json-bytes" id="ref-for-serialize-a-javascript-value-to-json-bytes">serializing a JavaScript value to JSON bytes</a>, given
+ <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①①">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-internal-map" id="ref-for-crashreportcontext-internal-map⑤">internal map</a>.</p>
+     <li data-md>
+      <p>If <var>serialization</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size">size</a> is > <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①②">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-buffer-length" id="ref-for-crashreportcontext-buffer-length①">buffer length</a>, then:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-remove" id="ref-for-map-remove">Remove</a> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①③">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-internal-map" id="ref-for-crashreportcontext-internal-map⑥">internal map</a>[<var>key</var>].</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-throw" id="ref-for-dfn-throw⑤">Throw</a> a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new⑤">new</a> "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror①">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException⑤">DOMException</a></code>.</p>
+      </ol>
+     <li data-md>
+      <p>Let <var>backing buffer ID</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①④">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-backing-buffer-id" id="ref-for-crashreportcontext-backing-buffer-id⑥">backing buffer ID</a>.</p>
+     <li data-md>
+      <p>Write <var>serialization</var> to the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#user-agent" id="ref-for-user-agent④">user agent</a>’s <a data-link-type="dfn" href="#user-agent-crash-report-buffers" id="ref-for-user-agent-crash-report-buffers③">crash report buffers</a>[<var>backing buffer ID</var>].</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="delete(key)" data-algorithm-for="CrashReportContext">
+    
+  The <dfn class="dfn-paneled idl-code" data-dfn-for="CrashReportContext" data-dfn-type="method" data-export id="dom-crashreportcontext-delete"><code>delete(<var>key</var>)</code></dfn> method steps are:
+
+
+    <ol>
+     <li data-md>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑤">this</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global⑤">relevant global object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window" id="ref-for-concept-document-window③">associated Document</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active" id="ref-for-fully-active③">fully active</a>, then <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-throw" id="ref-for-dfn-throw⑥">throw</a> a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new⑥">new</a> "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror④">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException⑥">DOMException</a></code>.</p>
+     <li data-md>
+      <p>If <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑥">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-is-buffer-initialized" id="ref-for-crashreportcontext-is-buffer-initialized②">is buffer initialized</a> is false, then <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-throw" id="ref-for-dfn-throw⑦">throw</a> a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new⑦">new</a>
+ "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#invalidstateerror" id="ref-for-invalidstateerror⑤">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException⑦">DOMException</a></code>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-remove" id="ref-for-map-remove①">Remove</a> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑦">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-internal-map" id="ref-for-crashreportcontext-internal-map⑦">internal map</a>[<var>key</var>].</p>
+     <li data-md>
+      <p>Let <var>serialization</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-json-bytes" id="ref-for-serialize-a-javascript-value-to-json-bytes①">serializing a JavaScript value to JSON bytes</a>, given
+ <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑧">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-internal-map" id="ref-for-crashreportcontext-internal-map⑧">internal map</a>.</p>
+     <li data-md>
+      <p>Let <var>backing buffer ID</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑨">this</a>’s <a data-link-type="dfn" href="#crashreportcontext-backing-buffer-id" id="ref-for-crashreportcontext-backing-buffer-id⑦">backing buffer ID</a>.</p>
+     <li data-md>
+      <p>Write <var>serialization</var> to the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#user-agent" id="ref-for-user-agent⑤">user agent</a>’s <a data-link-type="dfn" href="#user-agent-crash-report-buffers" id="ref-for-user-agent-crash-report-buffers④">crash report buffers</a>[<var>backing buffer ID</var>].</p>
+    </ol>
+   </div>
+   <h2 class="heading settled" data-level="5" id="document-policy"><span class="secno">5. </span><span class="content">Document Policy Integration</span><a class="self-link" href="#document-policy"></a></h2>
    <p>Site authors may opt in to recording the JavaScript call stack with some
 reports.</p>
    <p>This spec defines a <a data-link-type="dfn" href="https://wicg.github.io/document-policy/#configuration-point" id="ref-for-configuration-point">configuration point</a> with the name
@@ -891,8 +1100,8 @@ call stack, at the time of the crash, to be included in a crash report.</p>
 
 <pre class="http">Document-Policy: include-js-call-stacks-in-crash-reports</pre>
    </div>
-   <h2 class="heading settled" data-level="5" id="implementation"><span class="secno">5. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation"></a></h2>
-   <h3 class="heading settled" data-level="5.1" id="delivery"><span class="secno">5.1. </span><span class="content">Delivery</span><a class="self-link" href="#delivery"></a></h3>
+   <h2 class="heading settled" data-level="6" id="implementation"><span class="secno">6. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation"></a></h2>
+   <h3 class="heading settled" data-level="6.1" id="delivery"><span class="secno">6.1. </span><span class="content">Delivery</span><a class="self-link" href="#delivery"></a></h3>
    <p><a data-link-type="biblio" href="#biblio-reporting" title="Reporting API">[REPORTING]</a>, which defines the framework on which this specification depends,
 provides at most a best-efforts delivery mechanism. This is especially true when
 it comes to reporting crashes. There are probably always going to be certain
@@ -906,7 +1115,7 @@ responsible for that document crashes, or is terminated by the operating system.
    <p>There are multiple ways to implement such a monitor, with varying levels of
 reliability and robustness to specific crash causes, and this specification does
 not attempt to prescribe any particular such method.</p>
-   <h2 class="heading settled" data-level="6" id="sample-reports"><span class="secno">6. </span><span class="content">Sample Reports</span><a class="self-link" href="#sample-reports"></a></h2>
+   <h2 class="heading settled" data-level="7" id="sample-reports"><span class="secno">7. </span><span class="content">Sample Reports</span><a class="self-link" href="#sample-reports"></a></h2>
    <div class="example" id="example-d65bd545">
     <a class="self-link" href="#example-d65bd545"></a>
 
@@ -926,24 +1135,44 @@ Content-Type: application/reports+json
 }]
 </pre>
    </div>
-   <h2 class="heading settled" data-level="7" id="security"><span class="secno">7. </span><span class="content">Security Considerations</span><a class="self-link" href="#security"></a></h2>
+   <h2 class="heading settled" data-level="8" id="security"><span class="secno">8. </span><span class="content">Security Considerations</span><a class="self-link" href="#security"></a></h2>
    <p>For a discussion of security considerations surrounding out-of-band reporting in
 general, see <a href="https://w3c.github.io/reporting/#security"><cite>Reporting API</cite> § 8 Security Considerations</a>.</p>
    <p>The remainder of this section discusses security considerations for crash
 reporting specifically.</p>
-   <h2 class="heading settled" data-level="8" id="privacy"><span class="secno">8. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy"></a></h2>
+   <h2 class="heading settled" data-level="9" id="privacy"><span class="secno">9. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy"></a></h2>
    <p>For a discussion of privacy considerations surrounding out-of-band reporting in
 general, see <a href="https://w3c.github.io/reporting/#privacy"><cite>Reporting API</cite> § 9 Privacy Considerations</a>.</p>
    <p>The remainder of this section discusses privacy considerations for crash
 reporting specifically.</p>
-   <h3 class="heading settled" data-level="8.1" id="cross-process-contamination"><span class="secno">8.1. </span><span class="content">Cross-Process Contamination</span><a class="self-link" href="#cross-process-contamination"></a></h3>
+   <h3 class="heading settled" data-level="9.1" id="cross-process-contamination"><span class="secno">9.1. </span><span class="content">Cross-Process Contamination</span><a class="self-link" href="#cross-process-contamination"></a></h3>
   </main>
   <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
+   <li><a href="#crashreportcontext-backing-buffer-id">backing buffer ID</a><span>, in § 4</span>
+   <li><a href="#crashreportcontext-buffer-length">buffer length</a><span>, in § 4</span>
+   <li>
+    crashReport
+    <ul>
+     <li><a href="#dom-window-crashreport">attribute for Window</a><span>, in § 4</span>
+     <li><a href="#window-crashreport">dfn for Window</a><span>, in § 4</span>
+    </ul>
+   <li>
+    crash_report_api
+    <ul>
+     <li><a href="#crashreportbody-crash_report_api">dfn for CrashReportBody</a><span>, in § 3</span>
+     <li><a href="#dom-crashreportbody-crash_report_api">dict-member for CrashReportBody</a><span>, in § 3</span>
+    </ul>
    <li><a href="#dictdef-crashreportbody">CrashReportBody</a><span>, in § 3</span>
+   <li><a href="#user-agent-crash-report-buffers">crash report buffers</a><span>, in § 4</span>
+   <li><a href="#crashreportcontext">CrashReportContext</a><span>, in § 4</span>
    <li><a href="#crash-reports">Crash reports</a><span>, in § 3</span>
+   <li><a href="#dom-crashreportcontext-delete">delete(key)</a><span>, in § 4</span>
+   <li><a href="#dom-crashreportcontext-initialize">initialize(length)</a><span>, in § 4</span>
+   <li><a href="#crashreportcontext-internal-map">internal map</a><span>, in § 4</span>
+   <li><a href="#crashreportcontext-is-buffer-initialized">is buffer initialized</a><span>, in § 4</span>
    <li>
     is_top_level
     <ul>
@@ -956,6 +1185,7 @@ reporting specifically.</p>
      <li><a href="#crashreportbody-reason">dfn for CrashReportBody</a><span>, in § 3</span>
      <li><a href="#dom-crashreportbody-reason">dict-member for CrashReportBody</a><span>, in § 3</span>
     </ul>
+   <li><a href="#dom-crashreportcontext-set">set(key, value)</a><span>, in § 4</span>
    <li>
     stack
     <ul>
@@ -971,6 +1201,12 @@ reporting specifically.</p>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
+   <li>
+    <a data-link-type="biblio">[]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="2c610cb6">new unique internal value</span>
+     <li><span class="dfn-paneled" id="491a1d81">unique internal value</span>
+    </ul>
    <li>
     <a data-link-type="biblio">[DOCUMENT-POLICY]</a> defines the following terms:
     <ul>
@@ -991,8 +1227,29 @@ reporting specifically.</p>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="8b488914">DocumentVisibilityState</span>
+     <li><span class="dfn-paneled" id="5d7209e9">Window</span>
+     <li><span class="dfn-paneled" id="3349d69f">associated Document</span>
+     <li><span class="dfn-paneled" id="e10e7eb7">DOM manipulation task source</span>
+     <li><span class="dfn-paneled" id="0e3ba9f8">fully active</span>
+     <li><span class="dfn-paneled" id="a72449dd">in parallel</span>
+     <li><span class="dfn-paneled" id="48438eb3">queue a global task</span>
+     <li><span class="dfn-paneled" id="e99bd18e">relevant global object</span>
      <li><span class="dfn-paneled" id="bd736ec6">top-level traversable</span>
      <li><span class="dfn-paneled" id="c6d6dab1">visibilityState</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="36858240">boolean</span>
+     <li><span class="dfn-paneled" id="860300d4">implementation-defined</span>
+     <li><span class="dfn-paneled" id="31db57e6">keys</span>
+     <li><span class="dfn-paneled" id="3fca5a9e">map</span>
+     <li><span class="dfn-paneled" id="7d4424b2">remove</span>
+     <li><span class="dfn-paneled" id="70624575">serialize a JavaScript value to JSON bytes</span>
+     <li><span class="dfn-paneled" id="0e6b2056">set</span>
+     <li><span class="dfn-paneled" id="0204d188">size</span>
+     <li><span class="dfn-paneled" id="6d19ac93">user agent</span>
+     <li><span class="dfn-paneled" id="12d6b9a8">values</span>
     </ul>
    <li>
     <a data-link-type="biblio">[REPORTING]</a> defines the following terms:
@@ -1006,8 +1263,22 @@ reporting specifically.</p>
    <li>
     <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
     <ul>
+     <li><span class="dfn-paneled" id="dca2de17">DOMException</span>
      <li><span class="dfn-paneled" id="8855a9aa">DOMString</span>
+     <li><span class="dfn-paneled" id="889e932f">Exposed</span>
+     <li><span class="dfn-paneled" id="797018a7">InvalidStateError</span>
+     <li><span class="dfn-paneled" id="ba556545">NotAllowedError</span>
+     <li><span class="dfn-paneled" id="bdbd19d1">Promise</span>
+     <li><span class="dfn-paneled" id="dacde8b5">a new promise</span>
+     <li><span class="dfn-paneled" id="6c6b1005">any</span>
      <li><span class="dfn-paneled" id="5372cca8">boolean</span>
+     <li><span class="dfn-paneled" id="56f81a8e">new</span>
+     <li><span class="dfn-paneled" id="efd1ec5d">object</span>
+     <li><span class="dfn-paneled" id="3b90bdcd">resolve</span>
+     <li><span class="dfn-paneled" id="4013a022">this</span>
+     <li><span class="dfn-paneled" id="b4cfa5ce">throw</span>
+     <li><span class="dfn-paneled" id="5f90bbfb">undefined</span>
+     <li><span class="dfn-paneled" id="f14b47b8">unsigned long long</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -1019,6 +1290,8 @@ reporting specifically.</p>
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/"><cite>DOM Standard</cite></a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-infra">[INFRA]
+   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-reporting">[REPORTING]
    <dd>Douglas Creager; Ian Clelland; Mike West. <a href="https://w3c.github.io/reporting/"><cite>Reporting API</cite></a>. URL: <a href="https://w3c.github.io/reporting/">https://w3c.github.io/reporting/</a>
    <dt id="biblio-webidl">[WEBIDL]
@@ -1030,6 +1303,18 @@ reporting specifically.</p>
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <a data-type="DOMString" href="#dom-crashreportbody-stack"><code><c- g>stack</c-></code></a>;
   <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a data-type="boolean" href="#dom-crashreportbody-is_top_level"><code><c- g>is_top_level</c-></code></a>;
   <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#documentvisibilitystate"><c- n>DocumentVisibilityState</c-></a> <a data-type="DocumentVisibilityState" href="#dom-crashreportbody-visibility_state"><code><c- g>visibility_state</c-></code></a>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-object"><c- b>object</c-></a> <a data-type="object" href="#dom-crashreportbody-crash_report_api"><code><c- g>crash_report_api</c-></code></a>;
+};
+
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window"><c- g>Window</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#crashreportcontext"><c- n>CrashReportContext</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="CrashReportContext" href="#dom-window-crashreport"><c- g>crashReport</c-></a>;
+};
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <a href="#crashreportcontext"><code><c- g>CrashReportContext</c-></code></a> {
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-crashreportcontext-initialize"><c- g>initialize</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <a href="#dom-crashreportcontext-initialize-length-length"><code><c- g>length</c-></code></a>);
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-crashreportcontext-set"><c- g>set</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-crashreportcontext-set-key-value-key"><code><c- g>key</c-></code></a>, <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-crashreportcontext-set-key-value-value"><code><c- g>value</c-></code></a>);
+    <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-crashreportcontext-delete"><c- g>delete</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-crashreportcontext-delete-key-key"><code><c- g>key</c-></code></a>);
 };
 
 </pre>
@@ -1233,30 +1518,80 @@ function parseHTML(markup) {
 "use strict";
 {
 let dfnPanelData = {
+"0204d188": {"dfnID":"0204d188","dfnText":"size","external":true,"refSections":[{"refs":[{"id":"ref-for-list-size"}],"title":"4. The CrashReportContext interface"}],"url":"https://infra.spec.whatwg.org/#list-size"},
+"0e3ba9f8": {"dfnID":"0e3ba9f8","dfnText":"fully active","external":true,"refSections":[{"refs":[{"id":"ref-for-fully-active"},{"id":"ref-for-fully-active\u2460"},{"id":"ref-for-fully-active\u2461"},{"id":"ref-for-fully-active\u2462"}],"title":"4. The CrashReportContext interface"}],"url":"https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active"},
+"0e6b2056": {"dfnID":"0e6b2056","dfnText":"set","external":true,"refSections":[{"refs":[{"id":"ref-for-map-set"}],"title":"4. The CrashReportContext interface"}],"url":"https://infra.spec.whatwg.org/#map-set"},
+"12d6b9a8": {"dfnID":"12d6b9a8","dfnText":"values","external":true,"refSections":[{"refs":[{"id":"ref-for-map-getting-the-values"},{"id":"ref-for-map-getting-the-values\u2460"},{"id":"ref-for-map-getting-the-values\u2461"}],"title":"4. The CrashReportContext interface"}],"url":"https://infra.spec.whatwg.org/#map-getting-the-values"},
 "188c6617": {"dfnID":"188c6617","dfnText":"ReportBody","external":true,"refSections":[{"refs":[{"id":"ref-for-reportbody"}],"title":"3. Crash Reports"}],"url":"https://w3c.github.io/reporting/#reportbody"},
+"2c610cb6": {"dfnID":"2c610cb6","dfnText":"new unique internal value","external":true,"refSections":[{"refs":[{"id":"ref-for-new-unique-internal-value"}],"title":"4. The CrashReportContext interface"}],"url":"https://html.spec.whatwg.org/C#new-unique-internal-value"},
+"31db57e6": {"dfnID":"31db57e6","dfnText":"keys","external":true,"refSections":[{"refs":[{"id":"ref-for-map-getting-the-keys"},{"id":"ref-for-map-getting-the-keys\u2460"}],"title":"4. The CrashReportContext interface"}],"url":"https://infra.spec.whatwg.org/#map-getting-the-keys"},
+"3349d69f": {"dfnID":"3349d69f","dfnText":"associated Document","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-document-window"},{"id":"ref-for-concept-document-window\u2460"},{"id":"ref-for-concept-document-window\u2461"},{"id":"ref-for-concept-document-window\u2462"}],"title":"4. The CrashReportContext interface"}],"url":"https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window"},
+"36858240": {"dfnID":"36858240","dfnText":"boolean","external":true,"refSections":[{"refs":[{"id":"ref-for-boolean"}],"title":"4. The CrashReportContext interface"}],"url":"https://infra.spec.whatwg.org/#boolean"},
+"3b90bdcd": {"dfnID":"3b90bdcd","dfnText":"resolve","external":true,"refSections":[{"refs":[{"id":"ref-for-resolve"}],"title":"4. The CrashReportContext interface"}],"url":"https://webidl.spec.whatwg.org/#resolve"},
+"3fca5a9e": {"dfnID":"3fca5a9e","dfnText":"map","external":true,"refSections":[{"refs":[{"id":"ref-for-ordered-map"},{"id":"ref-for-ordered-map\u2460"},{"id":"ref-for-ordered-map\u2461"}],"title":"4. The CrashReportContext interface"}],"url":"https://infra.spec.whatwg.org/#ordered-map"},
+"4013a022": {"dfnID":"4013a022","dfnText":"this","external":true,"refSections":[{"refs":[{"id":"ref-for-this"},{"id":"ref-for-this\u2460"},{"id":"ref-for-this\u2461"},{"id":"ref-for-this\u2462"},{"id":"ref-for-this\u2463"},{"id":"ref-for-this\u2464"},{"id":"ref-for-this\u2465"},{"id":"ref-for-this\u2466"},{"id":"ref-for-this\u2467"},{"id":"ref-for-this\u2468"},{"id":"ref-for-this\u2460\u24ea"},{"id":"ref-for-this\u2460\u2460"},{"id":"ref-for-this\u2460\u2461"},{"id":"ref-for-this\u2460\u2462"},{"id":"ref-for-this\u2460\u2463"},{"id":"ref-for-this\u2460\u2464"},{"id":"ref-for-this\u2460\u2465"},{"id":"ref-for-this\u2460\u2466"},{"id":"ref-for-this\u2460\u2467"},{"id":"ref-for-this\u2460\u2468"}],"title":"4. The CrashReportContext interface"}],"url":"https://webidl.spec.whatwg.org/#this"},
+"48438eb3": {"dfnID":"48438eb3","dfnText":"queue a global task","external":true,"refSections":[{"refs":[{"id":"ref-for-queue-a-global-task"}],"title":"4. The CrashReportContext interface"}],"url":"https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task"},
+"491a1d81": {"dfnID":"491a1d81","dfnText":"unique internal value","external":true,"refSections":[{"refs":[{"id":"ref-for-unique-internal-value"},{"id":"ref-for-unique-internal-value\u2460"}],"title":"4. The CrashReportContext interface"}],"url":"https://html.spec.whatwg.org/C#unique-internal-value"},
 "4d5cebba": {"dfnID":"4d5cebba","dfnText":"report type","external":true,"refSections":[{"refs":[{"id":"ref-for-report-type"}],"title":"3. Crash Reports"}],"url":"https://w3c.github.io/reporting/#report-type"},
 "5372cca8": {"dfnID":"5372cca8","dfnText":"boolean","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-boolean"}],"title":"3. Crash Reports"}],"url":"https://webidl.spec.whatwg.org/#idl-boolean"},
+"56f81a8e": {"dfnID":"56f81a8e","dfnText":"new","external":true,"refSections":[{"refs":[{"id":"ref-for-new"},{"id":"ref-for-new\u2460"},{"id":"ref-for-new\u2461"},{"id":"ref-for-new\u2462"},{"id":"ref-for-new\u2463"},{"id":"ref-for-new\u2464"},{"id":"ref-for-new\u2465"},{"id":"ref-for-new\u2466"}],"title":"4. The CrashReportContext interface"}],"url":"https://webidl.spec.whatwg.org/#new"},
+"5d7209e9": {"dfnID":"5d7209e9","dfnText":"Window","external":true,"refSections":[{"refs":[{"id":"ref-for-window"},{"id":"ref-for-window\u2460"},{"id":"ref-for-window\u2461"}],"title":"4. The CrashReportContext interface"}],"url":"https://html.spec.whatwg.org/multipage/nav-history-apis.html#window"},
+"5f90bbfb": {"dfnID":"5f90bbfb","dfnText":"undefined","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-undefined"},{"id":"ref-for-idl-undefined\u2460"},{"id":"ref-for-idl-undefined\u2461"},{"id":"ref-for-idl-undefined\u2462"}],"title":"4. The CrashReportContext interface"}],"url":"https://webidl.spec.whatwg.org/#idl-undefined"},
+"6c6b1005": {"dfnID":"6c6b1005","dfnText":"any","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-any"}],"title":"3. Crash Reports"}],"url":"https://webidl.spec.whatwg.org/#idl-any"},
+"6d19ac93": {"dfnID":"6d19ac93","dfnText":"user agent","external":true,"refSections":[{"refs":[{"id":"ref-for-user-agent"}],"title":"3. Crash Reports"},{"refs":[{"id":"ref-for-user-agent\u2460"},{"id":"ref-for-user-agent\u2461"},{"id":"ref-for-user-agent\u2462"},{"id":"ref-for-user-agent\u2463"},{"id":"ref-for-user-agent\u2464"}],"title":"4. The CrashReportContext interface"}],"url":"https://infra.spec.whatwg.org/#user-agent"},
+"70624575": {"dfnID":"70624575","dfnText":"serialize a JavaScript value to JSON bytes","external":true,"refSections":[{"refs":[{"id":"ref-for-serialize-a-javascript-value-to-json-bytes"},{"id":"ref-for-serialize-a-javascript-value-to-json-bytes\u2460"}],"title":"4. The CrashReportContext interface"}],"url":"https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-json-bytes"},
+"797018a7": {"dfnID":"797018a7","dfnText":"InvalidStateError","external":true,"refSections":[{"refs":[{"id":"ref-for-invalidstateerror"},{"id":"ref-for-invalidstateerror\u2460"},{"id":"ref-for-invalidstateerror\u2461"},{"id":"ref-for-invalidstateerror\u2462"},{"id":"ref-for-invalidstateerror\u2463"},{"id":"ref-for-invalidstateerror\u2464"}],"title":"4. The CrashReportContext interface"}],"url":"https://webidl.spec.whatwg.org/#invalidstateerror"},
+"7d4424b2": {"dfnID":"7d4424b2","dfnText":"remove","external":true,"refSections":[{"refs":[{"id":"ref-for-map-remove"},{"id":"ref-for-map-remove\u2460"}],"title":"4. The CrashReportContext interface"}],"url":"https://infra.spec.whatwg.org/#map-remove"},
 "84afeaae": {"dfnID":"84afeaae","dfnText":"Error.prototype.stack","external":true,"refSections":[{"refs":[{"id":"ref-for-sec-get-error.prototype-stack"}],"title":"3. Crash Reports"}],"url":"https://tc39.es/proposal-error-stacks/#sec-get-error.prototype-stack"},
-"85394472": {"dfnID":"85394472","dfnText":"Document","external":true,"refSections":[{"refs":[{"id":"ref-for-document"},{"id":"ref-for-document\u2460"},{"id":"ref-for-document\u2461"}],"title":"3. Crash Reports"}],"url":"https://dom.spec.whatwg.org/#document"},
-"8855a9aa": {"dfnID":"8855a9aa","dfnText":"DOMString","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-DOMString"},{"id":"ref-for-idl-DOMString\u2460"}],"title":"3. Crash Reports"}],"url":"https://webidl.spec.whatwg.org/#idl-DOMString"},
+"85394472": {"dfnID":"85394472","dfnText":"Document","external":true,"refSections":[{"refs":[{"id":"ref-for-document"},{"id":"ref-for-document\u2460"},{"id":"ref-for-document\u2461"},{"id":"ref-for-document\u2462"}],"title":"3. Crash Reports"}],"url":"https://dom.spec.whatwg.org/#document"},
+"860300d4": {"dfnID":"860300d4","dfnText":"implementation-defined","external":true,"refSections":[{"refs":[{"id":"ref-for-implementation-defined"},{"id":"ref-for-implementation-defined\u2460"}],"title":"4. The CrashReportContext interface"}],"url":"https://infra.spec.whatwg.org/#implementation-defined"},
+"8855a9aa": {"dfnID":"8855a9aa","dfnText":"DOMString","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-DOMString"},{"id":"ref-for-idl-DOMString\u2460"}],"title":"3. Crash Reports"},{"refs":[{"id":"ref-for-idl-DOMString\u2461"},{"id":"ref-for-idl-DOMString\u2462"},{"id":"ref-for-idl-DOMString\u2463"},{"id":"ref-for-idl-DOMString\u2464"}],"title":"4. The CrashReportContext interface"}],"url":"https://webidl.spec.whatwg.org/#idl-DOMString"},
+"889e932f": {"dfnID":"889e932f","dfnText":"Exposed","external":true,"refSections":[{"refs":[{"id":"ref-for-Exposed"}],"title":"4. The CrashReportContext interface"}],"url":"https://webidl.spec.whatwg.org/#Exposed"},
 "8b488914": {"dfnID":"8b488914","dfnText":"DocumentVisibilityState","external":true,"refSections":[{"refs":[{"id":"ref-for-documentvisibilitystate"},{"id":"ref-for-documentvisibilitystate\u2460"}],"title":"3. Crash Reports"}],"url":"https://html.spec.whatwg.org/multipage/dom.html#documentvisibilitystate"},
 "9239678f": {"dfnID":"9239678f","dfnText":"endpoint","external":true,"refSections":[{"refs":[{"id":"ref-for-endpoint"},{"id":"ref-for-endpoint\u2460"},{"id":"ref-for-endpoint\u2461"}],"title":"3.1. Crash Reports Delivery Priority"}],"url":"https://w3c.github.io/reporting/#endpoint"},
 "9fe8836b": {"dfnID":"9fe8836b","dfnText":"report","external":true,"refSections":[{"refs":[{"id":"ref-for-report"}],"title":"3. Crash Reports"}],"url":"https://w3c.github.io/reporting/#report"},
-"a973e0fe": {"dfnID":"a973e0fe","dfnText":"document","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-document"}],"title":"3. Crash Reports"},{"refs":[{"id":"ref-for-concept-document\u2460"}],"title":"4. Document Policy Integration"}],"url":"https://dom.spec.whatwg.org/#concept-document"},
+"a72449dd": {"dfnID":"a72449dd","dfnText":"in parallel","external":true,"refSections":[{"refs":[{"id":"ref-for-in-parallel"}],"title":"4. The CrashReportContext interface"}],"url":"https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel"},
+"a973e0fe": {"dfnID":"a973e0fe","dfnText":"document","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-document"}],"title":"3. Crash Reports"},{"refs":[{"id":"ref-for-concept-document\u2460"}],"title":"5. Document Policy Integration"}],"url":"https://dom.spec.whatwg.org/#concept-document"},
+"b4cfa5ce": {"dfnID":"b4cfa5ce","dfnText":"throw","external":true,"refSections":[{"refs":[{"id":"ref-for-dfn-throw"},{"id":"ref-for-dfn-throw\u2460"},{"id":"ref-for-dfn-throw\u2461"},{"id":"ref-for-dfn-throw\u2462"},{"id":"ref-for-dfn-throw\u2463"},{"id":"ref-for-dfn-throw\u2464"},{"id":"ref-for-dfn-throw\u2465"},{"id":"ref-for-dfn-throw\u2466"}],"title":"4. The CrashReportContext interface"}],"url":"https://webidl.spec.whatwg.org/#dfn-throw"},
+"ba556545": {"dfnID":"ba556545","dfnText":"NotAllowedError","external":true,"refSections":[{"refs":[{"id":"ref-for-notallowederror"},{"id":"ref-for-notallowederror\u2460"}],"title":"4. The CrashReportContext interface"}],"url":"https://webidl.spec.whatwg.org/#notallowederror"},
 "bd736ec6": {"dfnID":"bd736ec6","dfnText":"top-level traversable","external":true,"refSections":[{"refs":[{"id":"ref-for-top-level-traversable"}],"title":"3. Crash Reports"}],"url":"https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-traversable"},
+"bdbd19d1": {"dfnID":"bdbd19d1","dfnText":"Promise","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-promise"},{"id":"ref-for-idl-promise\u2460"},{"id":"ref-for-idl-promise\u2461"}],"title":"4. The CrashReportContext interface"}],"url":"https://webidl.spec.whatwg.org/#idl-promise"},
 "c6d6dab1": {"dfnID":"c6d6dab1","dfnText":"visibilityState","external":true,"refSections":[{"refs":[{"id":"ref-for-dom-document-visibilitystate"}],"title":"3. Crash Reports"}],"url":"https://html.spec.whatwg.org/multipage/interaction.html#dom-document-visibilitystate"},
-"ccd8b64e": {"dfnID":"ccd8b64e","dfnText":"configuration point","external":true,"refSections":[{"refs":[{"id":"ref-for-configuration-point"}],"title":"4. Document Policy Integration"}],"url":"https://wicg.github.io/document-policy/#configuration-point"},
+"ccd8b64e": {"dfnID":"ccd8b64e","dfnText":"configuration point","external":true,"refSections":[{"refs":[{"id":"ref-for-configuration-point"}],"title":"5. Document Policy Integration"}],"url":"https://wicg.github.io/document-policy/#configuration-point"},
 "cf363990": {"dfnID":"cf363990","dfnText":"body","external":true,"refSections":[{"refs":[{"id":"ref-for-report-body"}],"title":"3. Crash Reports"}],"url":"https://w3c.github.io/reporting/#report-body"},
-"crash-reports": {"dfnID":"crash-reports","dfnText":"Crash reports","external":false,"refSections":[{"refs":[{"id":"ref-for-crash-reports"},{"id":"ref-for-crash-reports\u2460"},{"id":"ref-for-crash-reports\u2461"}],"title":"3. Crash Reports"},{"refs":[{"id":"ref-for-crash-reports\u2462"},{"id":"ref-for-crash-reports\u2463"},{"id":"ref-for-crash-reports\u2464"},{"id":"ref-for-crash-reports\u2465"}],"title":"3.1. Crash Reports Delivery Priority"}],"url":"#crash-reports"},
+"crash-reports": {"dfnID":"crash-reports","dfnText":"Crash reports","external":false,"refSections":[{"refs":[{"id":"ref-for-crash-reports"},{"id":"ref-for-crash-reports\u2460"},{"id":"ref-for-crash-reports\u2461"}],"title":"3. Crash Reports"},{"refs":[{"id":"ref-for-crash-reports\u2462"},{"id":"ref-for-crash-reports\u2463"},{"id":"ref-for-crash-reports\u2464"},{"id":"ref-for-crash-reports\u2465"}],"title":"3.1. Crash Reports Delivery Priority"},{"refs":[{"id":"ref-for-crash-reports\u2466"}],"title":"4. The CrashReportContext interface"}],"url":"#crash-reports"},
+"crashreportbody-crash_report_api": {"dfnID":"crashreportbody-crash_report_api","dfnText":"crash_report_api","external":false,"refSections":[],"url":"#crashreportbody-crash_report_api"},
 "crashreportbody-is_top_level": {"dfnID":"crashreportbody-is_top_level","dfnText":"is_top_level","external":false,"refSections":[],"url":"#crashreportbody-is_top_level"},
 "crashreportbody-reason": {"dfnID":"crashreportbody-reason","dfnText":"reason","external":false,"refSections":[{"refs":[{"id":"ref-for-crashreportbody-reason"},{"id":"ref-for-crashreportbody-reason\u2460"},{"id":"ref-for-crashreportbody-reason\u2461"}],"title":"3. Crash Reports"}],"url":"#crashreportbody-reason"},
 "crashreportbody-stack": {"dfnID":"crashreportbody-stack","dfnText":"stack","external":false,"refSections":[{"refs":[{"id":"ref-for-crashreportbody-stack"}],"title":"3. Crash Reports"}],"url":"#crashreportbody-stack"},
 "crashreportbody-visibility_state": {"dfnID":"crashreportbody-visibility_state","dfnText":"visibility_state","external":false,"refSections":[],"url":"#crashreportbody-visibility_state"},
-"dictdef-crashreportbody": {"dfnID":"dictdef-crashreportbody","dfnText":"CrashReportBody","external":false,"refSections":[{"refs":[{"id":"ref-for-dictdef-crashreportbody"}],"title":"3. Crash Reports"}],"url":"#dictdef-crashreportbody"},
+"crashreportcontext": {"dfnID":"crashreportcontext","dfnText":"CrashReportContext","external":false,"refSections":[{"refs":[{"id":"ref-for-crashreportcontext"}],"title":"3. Crash Reports"},{"refs":[{"id":"ref-for-crashreportcontext\u2460"},{"id":"ref-for-crashreportcontext\u2461"},{"id":"ref-for-crashreportcontext\u2462"},{"id":"ref-for-crashreportcontext\u2463"},{"id":"ref-for-crashreportcontext\u2464"},{"id":"ref-for-crashreportcontext\u2465"},{"id":"ref-for-crashreportcontext\u2466"}],"title":"4. The CrashReportContext interface"}],"url":"#crashreportcontext"},
+"crashreportcontext-backing-buffer-id": {"dfnID":"crashreportcontext-backing-buffer-id","dfnText":"backing buffer\nID","external":false,"refSections":[{"refs":[{"id":"ref-for-crashreportcontext-backing-buffer-id"}],"title":"3. Crash Reports"},{"refs":[{"id":"ref-for-crashreportcontext-backing-buffer-id\u2460"},{"id":"ref-for-crashreportcontext-backing-buffer-id\u2461"},{"id":"ref-for-crashreportcontext-backing-buffer-id\u2462"},{"id":"ref-for-crashreportcontext-backing-buffer-id\u2463"},{"id":"ref-for-crashreportcontext-backing-buffer-id\u2464"},{"id":"ref-for-crashreportcontext-backing-buffer-id\u2465"},{"id":"ref-for-crashreportcontext-backing-buffer-id\u2466"}],"title":"4. The CrashReportContext interface"}],"url":"#crashreportcontext-backing-buffer-id"},
+"crashreportcontext-buffer-length": {"dfnID":"crashreportcontext-buffer-length","dfnText":"buffer length","external":false,"refSections":[{"refs":[{"id":"ref-for-crashreportcontext-buffer-length"},{"id":"ref-for-crashreportcontext-buffer-length\u2460"}],"title":"4. The CrashReportContext interface"}],"url":"#crashreportcontext-buffer-length"},
+"crashreportcontext-internal-map": {"dfnID":"crashreportcontext-internal-map","dfnText":"internal map","external":false,"refSections":[{"refs":[{"id":"ref-for-crashreportcontext-internal-map"},{"id":"ref-for-crashreportcontext-internal-map\u2460"},{"id":"ref-for-crashreportcontext-internal-map\u2461"},{"id":"ref-for-crashreportcontext-internal-map\u2462"},{"id":"ref-for-crashreportcontext-internal-map\u2463"},{"id":"ref-for-crashreportcontext-internal-map\u2464"},{"id":"ref-for-crashreportcontext-internal-map\u2465"},{"id":"ref-for-crashreportcontext-internal-map\u2466"},{"id":"ref-for-crashreportcontext-internal-map\u2467"}],"title":"4. The CrashReportContext interface"}],"url":"#crashreportcontext-internal-map"},
+"crashreportcontext-is-buffer-initialized": {"dfnID":"crashreportcontext-is-buffer-initialized","dfnText":"is buffer\ninitialized","external":false,"refSections":[{"refs":[{"id":"ref-for-crashreportcontext-is-buffer-initialized"},{"id":"ref-for-crashreportcontext-is-buffer-initialized\u2460"},{"id":"ref-for-crashreportcontext-is-buffer-initialized\u2461"}],"title":"4. The CrashReportContext interface"}],"url":"#crashreportcontext-is-buffer-initialized"},
+"dacde8b5": {"dfnID":"dacde8b5","dfnText":"a new promise","external":true,"refSections":[{"refs":[{"id":"ref-for-a-new-promise"}],"title":"4. The CrashReportContext interface"}],"url":"https://webidl.spec.whatwg.org/#a-new-promise"},
+"dca2de17": {"dfnID":"dca2de17","dfnText":"DOMException","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-DOMException"},{"id":"ref-for-idl-DOMException\u2460"},{"id":"ref-for-idl-DOMException\u2461"},{"id":"ref-for-idl-DOMException\u2462"},{"id":"ref-for-idl-DOMException\u2463"},{"id":"ref-for-idl-DOMException\u2464"},{"id":"ref-for-idl-DOMException\u2465"},{"id":"ref-for-idl-DOMException\u2466"}],"title":"4. The CrashReportContext interface"}],"url":"https://webidl.spec.whatwg.org/#idl-DOMException"},
+"dictdef-crashreportbody": {"dfnID":"dictdef-crashreportbody","dfnText":"CrashReportBody","external":false,"refSections":[{"refs":[{"id":"ref-for-dictdef-crashreportbody"},{"id":"ref-for-dictdef-crashreportbody\u2460"}],"title":"3. Crash Reports"},{"refs":[{"id":"ref-for-dictdef-crashreportbody\u2461"}],"title":"4. The CrashReportContext interface"}],"url":"#dictdef-crashreportbody"},
+"dom-crashreportbody-crash_report_api": {"dfnID":"dom-crashreportbody-crash_report_api","dfnText":"crash_report_api","external":false,"refSections":[],"url":"#dom-crashreportbody-crash_report_api"},
 "dom-crashreportbody-is_top_level": {"dfnID":"dom-crashreportbody-is_top_level","dfnText":"is_top_level","external":false,"refSections":[],"url":"#dom-crashreportbody-is_top_level"},
 "dom-crashreportbody-reason": {"dfnID":"dom-crashreportbody-reason","dfnText":"reason","external":false,"refSections":[],"url":"#dom-crashreportbody-reason"},
 "dom-crashreportbody-stack": {"dfnID":"dom-crashreportbody-stack","dfnText":"stack","external":false,"refSections":[],"url":"#dom-crashreportbody-stack"},
 "dom-crashreportbody-visibility_state": {"dfnID":"dom-crashreportbody-visibility_state","dfnText":"visibility_state","external":false,"refSections":[],"url":"#dom-crashreportbody-visibility_state"},
+"dom-crashreportcontext-delete": {"dfnID":"dom-crashreportcontext-delete","dfnText":"delete(key)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-crashreportcontext-delete"}],"title":"4. The CrashReportContext interface"}],"url":"#dom-crashreportcontext-delete"},
+"dom-crashreportcontext-delete-key-key": {"dfnID":"dom-crashreportcontext-delete-key-key","dfnText":"key","external":false,"refSections":[],"url":"#dom-crashreportcontext-delete-key-key"},
+"dom-crashreportcontext-initialize": {"dfnID":"dom-crashreportcontext-initialize","dfnText":"initialize(length)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-crashreportcontext-initialize"},{"id":"ref-for-dom-crashreportcontext-initialize\u2460"},{"id":"ref-for-dom-crashreportcontext-initialize\u2461"}],"title":"4. The CrashReportContext interface"}],"url":"#dom-crashreportcontext-initialize"},
+"dom-crashreportcontext-initialize-length-length": {"dfnID":"dom-crashreportcontext-initialize-length-length","dfnText":"length","external":false,"refSections":[],"url":"#dom-crashreportcontext-initialize-length-length"},
+"dom-crashreportcontext-set": {"dfnID":"dom-crashreportcontext-set","dfnText":"set(key, value)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-crashreportcontext-set"},{"id":"ref-for-dom-crashreportcontext-set\u2460"},{"id":"ref-for-dom-crashreportcontext-set\u2461"}],"title":"4. The CrashReportContext interface"}],"url":"#dom-crashreportcontext-set"},
+"dom-crashreportcontext-set-key-value-key": {"dfnID":"dom-crashreportcontext-set-key-value-key","dfnText":"key","external":false,"refSections":[],"url":"#dom-crashreportcontext-set-key-value-key"},
+"dom-crashreportcontext-set-key-value-value": {"dfnID":"dom-crashreportcontext-set-key-value-value","dfnText":"value","external":false,"refSections":[],"url":"#dom-crashreportcontext-set-key-value-value"},
+"dom-window-crashreport": {"dfnID":"dom-window-crashreport","dfnText":"crashReport","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-window-crashreport"}],"title":"4. The CrashReportContext interface"}],"url":"#dom-window-crashreport"},
+"e10e7eb7": {"dfnID":"e10e7eb7","dfnText":"DOM manipulation task source","external":true,"refSections":[{"refs":[{"id":"ref-for-dom-manipulation-task-source"}],"title":"4. The CrashReportContext interface"}],"url":"https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source"},
+"e99bd18e": {"dfnID":"e99bd18e","dfnText":"relevant global object","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-relevant-global"},{"id":"ref-for-concept-relevant-global\u2460"},{"id":"ref-for-concept-relevant-global\u2461"},{"id":"ref-for-concept-relevant-global\u2462"},{"id":"ref-for-concept-relevant-global\u2463"},{"id":"ref-for-concept-relevant-global\u2464"}],"title":"4. The CrashReportContext interface"}],"url":"https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global"},
+"efd1ec5d": {"dfnID":"efd1ec5d","dfnText":"object","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-object"}],"title":"3. Crash Reports"}],"url":"https://webidl.spec.whatwg.org/#idl-object"},
+"f14b47b8": {"dfnID":"f14b47b8","dfnText":"unsigned long long","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-unsigned-long-long"},{"id":"ref-for-idl-unsigned-long-long\u2460"}],"title":"4. The CrashReportContext interface"}],"url":"https://webidl.spec.whatwg.org/#idl-unsigned-long-long"},
+"user-agent-crash-report-buffers": {"dfnID":"user-agent-crash-report-buffers","dfnText":"crash report buffers","external":false,"refSections":[{"refs":[{"id":"ref-for-user-agent-crash-report-buffers"}],"title":"3. Crash Reports"},{"refs":[{"id":"ref-for-user-agent-crash-report-buffers\u2460"},{"id":"ref-for-user-agent-crash-report-buffers\u2461"},{"id":"ref-for-user-agent-crash-report-buffers\u2462"},{"id":"ref-for-user-agent-crash-report-buffers\u2463"}],"title":"4. The CrashReportContext interface"}],"url":"#user-agent-crash-report-buffers"},
+"window-crashreport": {"dfnID":"window-crashreport","dfnText":"crashReport","external":false,"refSections":[{"refs":[{"id":"ref-for-window-crashreport"}],"title":"4. The CrashReportContext interface"}],"url":"#window-crashreport"},
 };
 
 document.addEventListener("DOMContentLoaded", ()=>{
@@ -1648,20 +1983,64 @@ let refsData = {
 "#crash-reports": {"displayText":"crash reports","export":true,"for_":[],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"crash reports","type":"dfn","url":"#crash-reports"},
 "#crashreportbody-reason": {"displayText":"reason","export":true,"for_":["CrashReportBody"],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"reason","type":"dfn","url":"#crashreportbody-reason"},
 "#crashreportbody-stack": {"displayText":"stack","export":true,"for_":["CrashReportBody"],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"stack","type":"dfn","url":"#crashreportbody-stack"},
+"#crashreportcontext": {"displayText":"CrashReportContext","export":true,"for_":[],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"CrashReportContext","type":"interface","url":"#crashreportcontext"},
+"#crashreportcontext-backing-buffer-id": {"displayText":"backing buffer id","export":true,"for_":["CrashReportContext"],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"backing buffer id","type":"dfn","url":"#crashreportcontext-backing-buffer-id"},
+"#crashreportcontext-buffer-length": {"displayText":"buffer length","export":true,"for_":["CrashReportContext"],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"buffer length","type":"dfn","url":"#crashreportcontext-buffer-length"},
+"#crashreportcontext-internal-map": {"displayText":"internal map","export":true,"for_":["CrashReportContext"],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"internal map","type":"dfn","url":"#crashreportcontext-internal-map"},
+"#crashreportcontext-is-buffer-initialized": {"displayText":"is buffer initialized","export":true,"for_":["CrashReportContext"],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"is buffer initialized","type":"dfn","url":"#crashreportcontext-is-buffer-initialized"},
 "#dictdef-crashreportbody": {"displayText":"CrashReportBody","export":true,"for_":[],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"CrashReportBody","type":"dictionary","url":"#dictdef-crashreportbody"},
+"#dom-crashreportcontext-delete": {"displayText":"delete(key)","export":true,"for_":["CrashReportContext"],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"delete(key)","type":"method","url":"#dom-crashreportcontext-delete"},
+"#dom-crashreportcontext-initialize": {"displayText":"initialize(length)","export":true,"for_":["CrashReportContext"],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"initialize(length)","type":"method","url":"#dom-crashreportcontext-initialize"},
+"#dom-crashreportcontext-set": {"displayText":"set(key, value)","export":true,"for_":["CrashReportContext"],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"set(key, value)","type":"method","url":"#dom-crashreportcontext-set"},
+"#dom-window-crashreport": {"displayText":"crashReport","export":true,"for_":["Window"],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"crashReport","type":"attribute","url":"#dom-window-crashreport"},
+"#user-agent-crash-report-buffers": {"displayText":"crash report buffers","export":true,"for_":["user agent"],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"crash report buffers","type":"dfn","url":"#user-agent-crash-report-buffers"},
+"#window-crashreport": {"displayText":"crashreport","export":true,"for_":["Window"],"level":"1","normative":true,"shortname":"crash-reporting","spec":"crash-reporting-1","status":"local","text":"crashreport","type":"dfn","url":"#window-crashreport"},
 "https://dom.spec.whatwg.org/#concept-document": {"displayText":"document","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"document","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-document"},
 "https://dom.spec.whatwg.org/#document": {"displayText":"Document","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"Document","type":"interface","url":"https://dom.spec.whatwg.org/#document"},
+"https://html.spec.whatwg.org/C#new-unique-internal-value": {"displayText":"new unique internal value","export":true,"for_":[],"level":"1","normative":true,"shortname":"crash-reporting","spec":"","status":"anchor-block","text":"new unique internal value","type":"dfn","url":"https://html.spec.whatwg.org/C#new-unique-internal-value"},
+"https://html.spec.whatwg.org/C#unique-internal-value": {"displayText":"unique internal value","export":true,"for_":[],"level":"1","normative":true,"shortname":"crash-reporting","spec":"","status":"anchor-block","text":"unique internal value","type":"dfn","url":"https://html.spec.whatwg.org/C#unique-internal-value"},
+"https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active": {"displayText":"fully active","export":true,"for_":["Document"],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"fully active","type":"dfn","url":"https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active"},
 "https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-traversable": {"displayText":"top-level traversable","export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"top-level traversable","type":"dfn","url":"https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-traversable"},
 "https://html.spec.whatwg.org/multipage/dom.html#documentvisibilitystate": {"displayText":"DocumentVisibilityState","export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"DocumentVisibilityState","type":"enum","url":"https://html.spec.whatwg.org/multipage/dom.html#documentvisibilitystate"},
+"https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel": {"displayText":"in parallel","export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"in parallel","type":"dfn","url":"https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel"},
 "https://html.spec.whatwg.org/multipage/interaction.html#dom-document-visibilitystate": {"displayText":"visibilityState","export":true,"for_":["Document"],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"visibilityState","type":"attribute","url":"https://html.spec.whatwg.org/multipage/interaction.html#dom-document-visibilitystate"},
+"https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window": {"displayText":"associated Document","export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"associated document","type":"dfn","url":"https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window"},
+"https://html.spec.whatwg.org/multipage/nav-history-apis.html#window": {"displayText":"Window","export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"Window","type":"interface","url":"https://html.spec.whatwg.org/multipage/nav-history-apis.html#window"},
+"https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global": {"displayText":"relevant global object","export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"relevant global object","type":"dfn","url":"https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global"},
+"https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source": {"displayText":"DOM manipulation task source","export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"dom manipulation task source","type":"dfn","url":"https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source"},
+"https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task": {"displayText":"queue a global task","export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"queue a global task","type":"dfn","url":"https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task"},
+"https://infra.spec.whatwg.org/#boolean": {"displayText":"boolean","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"boolean","type":"dfn","url":"https://infra.spec.whatwg.org/#boolean"},
+"https://infra.spec.whatwg.org/#implementation-defined": {"displayText":"implementation-defined","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"implementation-defined","type":"dfn","url":"https://infra.spec.whatwg.org/#implementation-defined"},
+"https://infra.spec.whatwg.org/#list-size": {"displayText":"size","export":true,"for_":["list","stack","queue","set"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"size","type":"dfn","url":"https://infra.spec.whatwg.org/#list-size"},
+"https://infra.spec.whatwg.org/#map-getting-the-keys": {"displayText":"keys","export":true,"for_":["map"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"keys","type":"dfn","url":"https://infra.spec.whatwg.org/#map-getting-the-keys"},
+"https://infra.spec.whatwg.org/#map-getting-the-values": {"displayText":"values","export":true,"for_":["map"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"values","type":"dfn","url":"https://infra.spec.whatwg.org/#map-getting-the-values"},
+"https://infra.spec.whatwg.org/#map-remove": {"displayText":"remove","export":true,"for_":["map"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"remove","type":"dfn","url":"https://infra.spec.whatwg.org/#map-remove"},
+"https://infra.spec.whatwg.org/#map-set": {"displayText":"set","export":true,"for_":["map"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"set","type":"dfn","url":"https://infra.spec.whatwg.org/#map-set"},
+"https://infra.spec.whatwg.org/#ordered-map": {"displayText":"map","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"map","type":"dfn","url":"https://infra.spec.whatwg.org/#ordered-map"},
+"https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-json-bytes": {"displayText":"serialize a JavaScript value to JSON bytes","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"serialize a javascript value to json bytes","type":"dfn","url":"https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-json-bytes"},
+"https://infra.spec.whatwg.org/#user-agent": {"displayText":"user agent","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"user agent","type":"dfn","url":"https://infra.spec.whatwg.org/#user-agent"},
 "https://tc39.es/proposal-error-stacks/#sec-get-error.prototype-stack": {"displayText":"Error.prototype.stack","export":true,"for_":[],"level":"","normative":true,"shortname":"error stacks","spec":"error stacks","status":"anchor-block","text":"error.prototype.stack","type":"dfn","url":"https://tc39.es/proposal-error-stacks/#sec-get-error.prototype-stack"},
 "https://w3c.github.io/reporting/#endpoint": {"displayText":"endpoint","export":true,"for_":[],"level":"1","normative":true,"shortname":"reporting","spec":"reporting-1","status":"current","text":"endpoint","type":"dfn","url":"https://w3c.github.io/reporting/#endpoint"},
 "https://w3c.github.io/reporting/#report": {"displayText":"report","export":true,"for_":[],"level":"1","normative":true,"shortname":"reporting","spec":"reporting-1","status":"current","text":"report","type":"dfn","url":"https://w3c.github.io/reporting/#report"},
 "https://w3c.github.io/reporting/#report-body": {"displayText":"body","export":true,"for_":["report"],"level":"1","normative":true,"shortname":"reporting","spec":"reporting-1","status":"current","text":"body","type":"dfn","url":"https://w3c.github.io/reporting/#report-body"},
 "https://w3c.github.io/reporting/#report-type": {"displayText":"report type","export":true,"for_":[],"level":"1","normative":true,"shortname":"reporting","spec":"reporting-1","status":"current","text":"report type","type":"dfn","url":"https://w3c.github.io/reporting/#report-type"},
 "https://w3c.github.io/reporting/#reportbody": {"displayText":"ReportBody","export":true,"for_":[],"level":"1","normative":true,"shortname":"reporting","spec":"reporting-1","status":"current","text":"ReportBody","type":"dictionary","url":"https://w3c.github.io/reporting/#reportbody"},
+"https://webidl.spec.whatwg.org/#Exposed": {"displayText":"Exposed","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"Exposed","type":"extended-attribute","url":"https://webidl.spec.whatwg.org/#Exposed"},
+"https://webidl.spec.whatwg.org/#a-new-promise": {"displayText":"a new promise","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"a new promise","type":"dfn","url":"https://webidl.spec.whatwg.org/#a-new-promise"},
+"https://webidl.spec.whatwg.org/#dfn-throw": {"displayText":"throw","export":true,"for_":["exception"],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"throw","type":"dfn","url":"https://webidl.spec.whatwg.org/#dfn-throw"},
+"https://webidl.spec.whatwg.org/#idl-DOMException": {"displayText":"DOMException","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"DOMException","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-DOMException"},
 "https://webidl.spec.whatwg.org/#idl-DOMString": {"displayText":"DOMString","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"DOMString","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-DOMString"},
+"https://webidl.spec.whatwg.org/#idl-any": {"displayText":"any","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"any","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-any"},
 "https://webidl.spec.whatwg.org/#idl-boolean": {"displayText":"boolean","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"boolean","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-boolean"},
+"https://webidl.spec.whatwg.org/#idl-object": {"displayText":"object","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"object","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-object"},
+"https://webidl.spec.whatwg.org/#idl-promise": {"displayText":"Promise","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"Promise","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-promise"},
+"https://webidl.spec.whatwg.org/#idl-undefined": {"displayText":"undefined","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"undefined","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-undefined"},
+"https://webidl.spec.whatwg.org/#idl-unsigned-long-long": {"displayText":"unsigned long long","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"unsigned long long","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-unsigned-long-long"},
+"https://webidl.spec.whatwg.org/#invalidstateerror": {"displayText":"InvalidStateError","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"InvalidStateError","type":"exception","url":"https://webidl.spec.whatwg.org/#invalidstateerror"},
+"https://webidl.spec.whatwg.org/#new": {"displayText":"new","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"new","type":"dfn","url":"https://webidl.spec.whatwg.org/#new"},
+"https://webidl.spec.whatwg.org/#notallowederror": {"displayText":"NotAllowedError","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"NotAllowedError","type":"exception","url":"https://webidl.spec.whatwg.org/#notallowederror"},
+"https://webidl.spec.whatwg.org/#resolve": {"displayText":"resolve","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"resolve","type":"dfn","url":"https://webidl.spec.whatwg.org/#resolve"},
+"https://webidl.spec.whatwg.org/#this": {"displayText":"this","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"this","type":"dfn","url":"https://webidl.spec.whatwg.org/#this"},
 "https://wicg.github.io/document-policy/#configuration-point": {"displayText":"configuration point","export":true,"for_":[],"level":"1","normative":true,"shortname":"document-policy","spec":"document-policy","status":"current","text":"configuration point","type":"dfn","url":"https://wicg.github.io/document-policy/#configuration-point"},
 };
 
@@ -1864,5 +2243,92 @@ window.addEventListener("resize", () => {
     // Hide any open ref hint.
     hideAllRefHints();
 });
+}
+</script>
+<script>/* Boilerplate: script-var-click-highlighting */
+"use strict";
+{
+/*
+Color-choosing design:
+
+* Colors are ordered by goodness.
+* On clicking a var, give it the earliest color
+    with the lowest usage in the algorithm.
+* On re-clicking, re-use the var's most recent color
+    if that's not currently being used elsewhere.
+*/
+
+const COLOR_COUNT = 7;
+
+document.addEventListener("click", e=>{
+    if(e.target.nodeName == "VAR") {
+        highlightSameAlgoVars(e.target);
+    }
+});
+
+function highlightSameAlgoVars(v) {
+    // Find the algorithm container.
+    let algoContainer = findAlgoContainer(v);
+
+    // Not highlighting document-global vars,
+    // too likely to be unrelated.
+    if(algoContainer == null) return;
+
+    const varName = nameFromVar(v);
+    if(!v.hasAttribute("data-var-color")) {
+        const newColor = chooseHighlightColor(algoContainer, v);
+        for(const el of algoContainer.querySelectorAll("var")) {
+            if(nameFromVar(el) == varName) {
+                el.setAttribute("data-var-color", newColor);
+                el.setAttribute("data-var-last-color", newColor);
+            }
+        }
+    } else {
+        for(const el of algoContainer.querySelectorAll("var")) {
+            if(nameFromVar(el) == varName) {
+                el.removeAttribute("data-var-color");
+            }
+        }
+    }
+}
+function findAlgoContainer(el) {
+    while(el != document.body) {
+        if(el.hasAttribute("data-algorithm")) return el;
+        el = el.parentNode;
+    }
+    return null;
+}
+function nameFromVar(el) {
+    return el.textContent.replace(/(\s|\xa0)+/g, " ").trim();
+}
+function colorCountsFromContainer(container) {
+    const namesFromColor = Array.from({length:COLOR_COUNT}, x=>new Set());
+    for(let v of container.querySelectorAll("var[data-var-color]")) {
+        let color = +v.getAttribute("data-var-color");
+        namesFromColor[color].add(nameFromVar(v));
+    }
+
+    return namesFromColor.map(x=>x.size);
+}
+function leastUsedColor(colors) {
+    // Find the earliest color with the lowest count.
+    let minCount = Infinity;
+    let minColor = null;
+    for(var i = 0; i < colors.length; i++) {
+        if(colors[i] < minCount) {
+            minColor = i;
+            minCount = colors[i];
+        }
+    }
+    return minColor;
+}
+function chooseHighlightColor(container, v) {
+    const colorCounts = colorCountsFromContainer(container);
+    if(v.hasAttribute("data-var-last-color")) {
+        let color = +v.getAttribute("data-var-last-color");
+        if(colorCounts[color] == 0) return color;
+    }
+    return leastUsedColor(colorCounts);
+}
 }
 </script>


### PR DESCRIPTION
Explainer: https://github.com/WICG/crash-reporting/blob/gh-pages/crashReport-explainer.md.

See also:
 - https://github.com/WICG/crash-reporting/issues/15
 - https://chromestatus.com/feature/6228675846209536
 - https://github.com/w3ctag/design-reviews/issues/1129
 - https://github.com/mozilla/standards-positions/issues/1271
 - https://github.com/WebKit/standards-positions/issues/528

Closes https://github.com/WICG/crash-reporting/issues/15. Closes https://github.com/WICG/crash-reporting/issues/38.